### PR TITLE
HIP-0019 pushes default ignore file functionality into Ignorer, injects `debug()` func from caller

### DIFF
--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -45,7 +45,6 @@ or recommendation, it will emit [WARNING] messages.
 
 func newLintCmd(out io.Writer) *cobra.Command {
 	client := action.NewLint()
-	client.Debug = settings.Debug
 	valueOpts := &values.Options{}
 	var kubeVersion string
 	var lintIgnoreFilePath string

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -107,17 +107,13 @@ func newLintCmd(out io.Writer) *cobra.Command {
 					debug("\nNo HelmLintIgnore file specified, will try and use the following: %s\n", lintIgnoreFilePath)
 					useTempFile = true // Mark that a temporary file was used
 				}
-				ignorer, err := lint.NewIgnorer(lintIgnoreFilePath)
-				if err != nil {
-					debug("Unable to load lint ignore rules: %s", err.Error())
-					ignorer = &lint.Ignorer{Patterns: map[string][]string{} }
-				}
+				ignorer := lint.NewIgnorer(lintIgnoreFilePath)
 				if useTempFile {
 					lintIgnoreFilePath = ""
 				}
 				result := client.Run([]string{path}, vals)
-				result.Messages = ignorer.FilterIgnoredMessages(result.Messages)
-				result.Errors = ignorer.FilterIgnoredErrors(result.Errors)
+				result.Messages = ignorer.FilterMessages(result.Messages)
+				result.Errors = ignorer.FilterErrors(result.Errors)
 
 				// If there are no errors/warnings and quiet flag is set
 				// go to the next chart

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -95,19 +95,11 @@ func newLintCmd(out io.Writer) *cobra.Command {
 			errorsOrWarnings := 0
 
 			for _, path := range paths {
-				// try to build lint ignorer from available helm lint ignore file
-				var ignorer *lint.Ignorer
-				if lintIgnoreFilePath != "" {
-					debug("\nUsing ignore file: %s\n", lintIgnoreFilePath)
-					ignorer = lint.NewIgnorer(lintIgnoreFilePath)
-				} else {
-					lintIgnoreFilePath = filepath.Join(path, lint.DefaultIgnoreFileName)
-					debug("\nNo HelmLintIgnore file specified, will try and use the following: %s\n", lintIgnoreFilePath)
-					ignorer = lint.NewIgnorer(lint.DefaultIgnoreFileName)
-				}
-
 				// lint the file
 				result := client.Run([]string{path}, vals)
+
+				// try to build lint ignorer from available helm lint ignore file
+				ignorer := lint.NewIgnorer(path, lintIgnoreFilePath)
 
 				// discard ignored messages and errors
 				result.Messages = ignorer.FilterMessages(result.Messages)

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -99,7 +99,7 @@ func newLintCmd(out io.Writer) *cobra.Command {
 				result := client.Run([]string{path}, vals)
 
 				// try to build lint ignorer from available helm lint ignore file
-				ignorer := lint.NewIgnorer(path, lintIgnoreFilePath)
+				ignorer := lint.NewIgnorer(path, lintIgnoreFilePath, debug)
 
 				// discard ignored messages and errors
 				result.Messages = ignorer.FilterMessages(result.Messages)

--- a/cmd/helm/lint_test.go
+++ b/cmd/helm/lint_test.go
@@ -90,3 +90,8 @@ func TestLintCmdWithKubeVersionFlag(t *testing.T) {
 	}}
 	runTestCmd(t, tests)
 }
+
+func TestLintFileCompletion(t *testing.T) {
+	checkFileCompletion(t, "lint", true)
+	checkFileCompletion(t, "lint mypath", true) // Multiple paths can be given
+}

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -20,7 +20,6 @@ type Lint struct {
     Quiet         bool
     KubeVersion   *chartutil.KubeVersion
     IgnoreFilePath string
-    Debug bool
 }
 type LintResult struct {
     TotalChartsLinted int

--- a/pkg/lint/ignore.go
+++ b/pkg/lint/ignore.go
@@ -15,6 +15,8 @@ type Ignorer struct {
 	DebugLogger *log.Logger
 }
 
+const DefaultIgnoreFileName = ".helmlintignore"
+
 func NewIgnorer(ignoreFilePath string) *Ignorer {
 	ignorer := &Ignorer{}
 	ignorer.loadPatternsFromFilePath(ignoreFilePath)

--- a/pkg/lint/ignore.go
+++ b/pkg/lint/ignore.go
@@ -2,7 +2,6 @@ package lint
 
 import (
 	"bufio"
-	"fmt"
 	"helm.sh/helm/v3/pkg/lint/support"
 	"log"
 	"os"
@@ -12,14 +11,13 @@ import (
 
 type Ignorer struct {
 	Patterns map[string][]string
-	DebugLogger *log.Logger
+	debug func(string, ...interface{})
 }
 
 const DefaultIgnoreFileName = ".helmlintignore"
 
-func NewIgnorer(chartPath, ignoreFilePath string) *Ignorer {
-	ignorer := &Ignorer{}
-
+func NewIgnorer(chartPath, ignoreFilePath string, debugFn func(string, ...interface{})) *Ignorer {
+	ignorer := &Ignorer{ debug: debugFn }
 
 	if ignoreFilePath == "" {
 		ignoreFilePath = filepath.Join(chartPath, DefaultIgnoreFileName)
@@ -117,16 +115,6 @@ func (i *Ignorer) loadPatternsFromFilePath(filePath string) {
 	}
 	return
 }
-
-func (i *Ignorer) debug(format string, v ...interface{}) {
-		format = fmt.Sprintf("[debug] %s\n", format)
-		if i.DebugLogger == nil {
-			var debugLogger = log.New(os.Stderr, "[debug] ", log.Lshortfile)
-			i.DebugLogger = debugLogger
-		}
-		i.DebugLogger.Output(2, fmt.Sprintf(format, v...))
-}
-
 
 /* TODO HIP-0019
 - find ignore file path for a subchart

--- a/pkg/lint/ignore.go
+++ b/pkg/lint/ignore.go
@@ -17,8 +17,16 @@ type Ignorer struct {
 
 const DefaultIgnoreFileName = ".helmlintignore"
 
-func NewIgnorer(ignoreFilePath string) *Ignorer {
+func NewIgnorer(chartPath, ignoreFilePath string) *Ignorer {
 	ignorer := &Ignorer{}
+
+
+	if ignoreFilePath == "" {
+		ignoreFilePath = filepath.Join(chartPath, DefaultIgnoreFileName)
+		ignorer.debug("\nNo HelmLintIgnore file specified, will try and use the following: %s\n", ignoreFilePath)
+	}
+
+	ignorer.debug("\nUsing ignore file: %s\n", ignoreFilePath)
 	ignorer.loadPatternsFromFilePath(ignoreFilePath)
 	return ignorer
 }

--- a/pkg/lint/ignore_test.go
+++ b/pkg/lint/ignore_test.go
@@ -65,8 +65,8 @@ func TestFilterIgnoredMessages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ignorer := Ignorer{Patterns: tt.args.ignorePatterns}
-			got := ignorer.FilterIgnoredMessages(tt.args.messages)
-			assert.Equalf(t, tt.want, got, "FilterIgnoredMessages(%v, %v)", tt.args.messages, tt.args.ignorePatterns)
+			got := ignorer.FilterMessages(tt.args.messages)
+			assert.Equalf(t, tt.want, got, "FilterMessages(%v, %v)", tt.args.messages, tt.args.ignorePatterns)
 		})
 	}
 }


### PR DESCRIPTION
- Push the default `.helmlintignore` fallback option down from `main` into `lint`
- Replaced the hacky `debug()` function from our `lint` package with a reference to the existing `debug` function used in `main`.