### PR TITLE
Dumps lint ignorer inputs to text file as json lines

### DIFF
--- a/pkg/lint/ignore_test.go
+++ b/pkg/lint/ignore_test.go
@@ -5,9 +5,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/lint/support"
 	"path/filepath"
+	"strings"
 	"testing"
 	"text/template"
 )
+
+// NewFromString builds a new Ignorer when provided a string representing the contents of a .helmlintignore file.
+// This should be especially useful for testing.
+func newFromString(s string) *Ignorer {
+	out := &Ignorer{
+		Patterns:      make(map[string][]string),
+		ErrorPatterns: make(map[string][]string),
+	}
+
+	rdr := strings.NewReader(s)
+	out.loadFromReader(rdr)
+	return out
+}
 
 func TestNewIgnorer(t *testing.T) {
 	chartPath := "rules/testdata/withsubchartlintignore"

--- a/pkg/lint/support/capture.go
+++ b/pkg/lint/support/capture.go
@@ -1,0 +1,84 @@
+package support
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+const outFilePath = "ignorer-inputs.jsonl"
+
+type DumpMessage struct {
+	Kind     string `json:"kind"`
+	Index    int    `json:"index,omitempty"`
+	Severity int    `json:"severity"`
+	Path     string `json:"path"`
+	ErrText  string `json:"err_text"`
+}
+
+type DumpError struct {
+	Kind    string `json:"kind"`
+	Index   int    `json:"index,omitempty"`
+	ErrText string `json:"err_text"`
+}
+
+// DumpInputsAsJsonLines takes slices of Messages and errors and dumps them
+// to outFilePath as a series of single-line JSON payloads.
+func DumpInputsAsJsonLines(messages []Message, errors []error) {
+	f, closer := openOutputFile(outFilePath)
+	defer closer()
+	dumpMessages(f, messages...)
+	dumpErrors(f, errors...)
+	f.Sync()
+}
+
+func dumpErrors(w io.Writer, errors ...error) {
+	for i, err := range errors {
+		de := DumpError{Kind: "error", Index: i, ErrText: err.Error()}
+		jsonBytes, err := json.Marshal(de)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Fprintf(w, "%s\n", jsonBytes)
+	}
+
+}
+
+func dumpMessages(w io.Writer, messages ...Message) {
+	for i, message := range messages {
+		dm := DumpMessage{
+			Kind:     "message",
+			Index:    i,
+			Severity: message.Severity,
+			Path:     message.Path,
+			ErrText:  message.Err.Error(),
+		}
+		jsonBytes, err := json.Marshal(dm)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Fprintf(w, "%s\n", jsonBytes)
+	}
+}
+
+// - opens an output file
+// - creates it if it doesn't exist already
+// - will append to the file rather than truncating
+func openOutputFile(p string) (*os.File, func()) {
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	closeFile := func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	closeFn := func() { closeFile(f) }
+
+	return f, closeFn
+}


### PR DESCRIPTION
I've added some code to dump the `[]support.Message` and `[]error` inputs our ignorer is having to contend with to a text file. Having these available as test fixtures should help us design better test cases and cleaner solutions.

Sample `ignorer-inputs.jsonl` file output:

```jsonl
{"kind":"message","severity":3,"path":"templates/","err_text":"template: certmanager-issuer/templates/rbac-config.yaml:1:67: executing \"certmanager-issuer/templates/rbac-config.yaml\" at \u003c.Values.global.ingress\u003e: nil pointer evaluating interface {}.ingress"}
{"kind":"error","err_text":"template: certmanager-issuer/templates/rbac-config.yaml:1:67: executing \"certmanager-issuer/templates/rbac-config.yaml\" at \u003c.Values.global.ingress\u003e: nil pointer evaluating interface {}.ingress"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: gitlab/charts/webservice/templates/tests/tests.yaml:5:20: executing \"gitlab/charts/webservice/templates/tests/tests.yaml\" at \u003c{{template \"fullname\" .}}\u003e: template \"fullname\" not defined"}
{"kind":"message","index":1,"severity":3,"path":"/Users/daniel/radius/bb/gitlab/chart/charts/gitlab","err_text":"chart metadata is missing these dependencies: kas,mailroom,migrations,geo-logcursor,gitaly,gitlab-exporter,gitlab-shell,sidekiq,spamcheck,toolbox,webservice"}
{"kind":"error","err_text":"template: gitlab/charts/webservice/templates/tests/tests.yaml:5:20: executing \"gitlab/charts/webservice/templates/tests/tests.yaml\" at \u003c{{template \"fullname\" .}}\u003e: template \"fullname\" not defined"}
{"kind":"error","index":1,"err_text":"chart metadata is missing these dependencies: kas,mailroom,migrations,geo-logcursor,gitaly,gitlab-exporter,gitlab-shell,sidekiq,spamcheck,toolbox,webservice"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: geo-logcursor/templates/serviceaccount.yaml:1:57: executing \"geo-logcursor/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"error","err_text":"template: geo-logcursor/templates/serviceaccount.yaml:1:57: executing \"geo-logcursor/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: gitaly/templates/statefulset.yml:1:11: executing \"gitaly/templates/statefulset.yml\" at \u003cinclude \"gitlab.gitaly.includeInternalResources\" $\u003e: error calling include: template: no template \"gitlab.gitaly.includeInternalResources\" associated with template \"gotpl\""}
{"kind":"error","err_text":"template: gitaly/templates/statefulset.yml:1:11: executing \"gitaly/templates/statefulset.yml\" at \u003cinclude \"gitlab.gitaly.includeInternalResources\" $\u003e: error calling include: template: no template \"gitlab.gitaly.includeInternalResources\" associated with template \"gotpl\""}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: gitlab-exporter/templates/serviceaccount.yaml:1:57: executing \"gitlab-exporter/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"error","err_text":"template: gitlab-exporter/templates/serviceaccount.yaml:1:57: executing \"gitlab-exporter/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: gitlab-pages/templates/serviceaccount.yaml:1:57: executing \"gitlab-pages/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"error","err_text":"template: gitlab-pages/templates/serviceaccount.yaml:1:57: executing \"gitlab-pages/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: gitlab-shell/templates/traefik-tcp-ingressroute.yaml:2:17: executing \"gitlab-shell/templates/traefik-tcp-ingressroute.yaml\" at \u003c.Values.global.ingress.provider\u003e: nil pointer evaluating interface {}.provider"}
{"kind":"error","err_text":"template: gitlab-shell/templates/traefik-tcp-ingressroute.yaml:2:17: executing \"gitlab-shell/templates/traefik-tcp-ingressroute.yaml\" at \u003c.Values.global.ingress.provider\u003e: nil pointer evaluating interface {}.provider"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: kas/templates/serviceaccount.yaml:1:57: executing \"kas/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"error","err_text":"template: kas/templates/serviceaccount.yaml:1:57: executing \"kas/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: mailroom/templates/serviceaccount.yaml:1:57: executing \"mailroom/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"error","err_text":"template: mailroom/templates/serviceaccount.yaml:1:57: executing \"mailroom/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: migrations/templates/job.yaml:2:3: executing \"migrations/templates/job.yaml\" at \u003cinclude (print $.Template.BasePath \"/_serviceaccountspec.yaml\") .\u003e: error calling include: template: migrations/templates/_serviceaccountspec.yaml:1:57: executing \"migrations/templates/_serviceaccountspec.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"error","err_text":"template: migrations/templates/job.yaml:2:3: executing \"migrations/templates/job.yaml\" at \u003cinclude (print $.Template.BasePath \"/_serviceaccountspec.yaml\") .\u003e: error calling include: template: migrations/templates/_serviceaccountspec.yaml:1:57: executing \"migrations/templates/_serviceaccountspec.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: praefect/templates/statefulset.yaml:1:38: executing \"praefect/templates/statefulset.yaml\" at \u003c.Values.global.image\u003e: nil pointer evaluating interface {}.image"}
{"kind":"error","err_text":"template: praefect/templates/statefulset.yaml:1:38: executing \"praefect/templates/statefulset.yaml\" at \u003c.Values.global.image\u003e: nil pointer evaluating interface {}.image"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: sidekiq/templates/serviceaccount.yaml:1:57: executing \"sidekiq/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"error","err_text":"template: sidekiq/templates/serviceaccount.yaml:1:57: executing \"sidekiq/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: spamcheck/templates/serviceaccount.yaml:1:57: executing \"spamcheck/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.serviceAccount"}
{"kind":"error","err_text":"template: spamcheck/templates/serviceaccount.yaml:1:57: executing \"spamcheck/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.serviceAccount"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: toolbox/templates/serviceaccount.yaml:1:57: executing \"toolbox/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"error","err_text":"template: toolbox/templates/serviceaccount.yaml:1:57: executing \"toolbox/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: webservice/templates/tests/tests.yaml:5:20: executing \"webservice/templates/tests/tests.yaml\" at \u003c{{template \"fullname\" .}}\u003e: template \"fullname\" not defined"}
{"kind":"error","err_text":"template: webservice/templates/tests/tests.yaml:5:20: executing \"webservice/templates/tests/tests.yaml\" at \u003c{{template \"fullname\" .}}\u003e: template \"fullname\" not defined"}
{"kind":"message","severity":1,"path":"Chart.yaml","err_text":"icon is recommended"}
{"kind":"message","severity":1,"path":"Chart.yaml","err_text":"icon is recommended"}
{"kind":"message","index":1,"severity":1,"path":"values.yaml","err_text":"file does not exist"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: minio/templates/pdb.yaml:3:24: executing \"minio/templates/pdb.yaml\" at \u003c{{template \"gitlab.pdb.apiVersion\" $pdbCfg}}\u003e: template \"gitlab.pdb.apiVersion\" not defined"}
{"kind":"error","err_text":"template: minio/templates/pdb.yaml:3:24: executing \"minio/templates/pdb.yaml\" at \u003c{{template \"gitlab.pdb.apiVersion\" $pdbCfg}}\u003e: template \"gitlab.pdb.apiVersion\" not defined"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: nginx-ingress/templates/admission-webhooks/job-patch/serviceaccount.yaml:13:40: executing \"nginx-ingress/templates/admission-webhooks/job-patch/serviceaccount.yaml\" at \u003c.Values.admissionWebhooks.serviceAccount.automountServiceAccountToken\u003e: nil pointer evaluating interface {}.serviceAccount"}
{"kind":"error","err_text":"template: nginx-ingress/templates/admission-webhooks/job-patch/serviceaccount.yaml:13:40: executing \"nginx-ingress/templates/admission-webhooks/job-patch/serviceaccount.yaml\" at \u003c.Values.admissionWebhooks.serviceAccount.automountServiceAccountToken\u003e: nil pointer evaluating interface {}.serviceAccount"}
{"kind":"message","severity":3,"path":"templates/","err_text":"template: registry/templates/serviceaccount.yaml:1:57: executing \"registry/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
{"kind":"error","err_text":"template: registry/templates/serviceaccount.yaml:1:57: executing \"registry/templates/serviceaccount.yaml\" at \u003c.Values.global.serviceAccount.enabled\u003e: nil pointer evaluating interface {}.enabled"}
```