### PR TITLE
Catches all linter inputs at action/lint/Run() and dumps them as JSON via slog to quickly collect test cases

### DIFF
--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -17,6 +17,7 @@ limitations under the License.
 package action
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,22 +60,62 @@ func (l *Lint) Run(paths []string, vals map[string]interface{}) *LintResult {
 		lowestTolerance = support.WarningSev
 	}
 	result := &LintResult{}
-	for _, path := range paths {
+	for chartIndex, path := range paths {
 		linter, err := lintChart(path, vals, l.Namespace, l.KubeVersion)
 		if err != nil {
 			result.Errors = append(result.Errors, err)
 			continue
 		}
+		logCapturedErrors(chartIndex, path, result.Errors)
+		result.Errors = filterErrors(chartIndex, path, result.Errors)
 
 		result.Messages = append(result.Messages, linter.Messages...)
+
+		logCapturedMessages(chartIndex, path, result.Messages)
+		result.Messages = filterMessages(chartIndex, path, result.Messages)
+
 		result.TotalChartsLinted++
 		for _, msg := range linter.Messages {
 			if msg.Severity >= lowestTolerance {
+				slog.Info("action/lint/Run is promoting a message to Error", "chartIndex", chartIndex, "path", path, "lowestTolerance", lowestTolerance, msg.LogAttrs())
 				result.Errors = append(result.Errors, msg.Err)
 			}
 		}
 	}
 	return result
+}
+
+func filterMessages(chartIndex int, path string, messages []support.Message) []support.Message {
+	out := make([]support.Message, 0, len(messages))
+	for _, msg := range messages {
+		// TODO: filter some messages based on content
+		out = append(out, msg)
+	}
+	return messages
+}
+
+func filterErrors(chartIndex int, path string, errs []error) []error {
+	out := make([]error, 0, len(errs))
+	for _, err := range errs {
+		// TODO: filter some errors based on content
+		out = append(out, err)
+	}
+	return errs
+}
+
+var logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+func logCapturedErrors(chartIndex int, path string, errors []error) {
+	for _, err := range errors {
+		logAttr := slog.Group("Err", slog.String("text", err.Error()))
+		logger.Info("action/lint/Run captured an error", "chartIndex", chartIndex, "path", path, logAttr)
+	}
+}
+
+func logCapturedMessages(chartIndex int, path string, messages []support.Message) {
+	for _, msg := range messages {
+		logger.Info("action/lint/Run captured a message", "chartIndex", chartIndex, "path", path, msg.LogAttrs())
+	}
 }
 
 // HasWarningsOrErrors checks is LintResult has any warnings or errors

--- a/pkg/lint/ignore/ignorer.go
+++ b/pkg/lint/ignore/ignorer.go
@@ -1,0 +1,40 @@
+package ignore
+
+import (
+	"helm.sh/helm/v3/pkg/lint/support"
+)
+
+type Ignorer struct {
+
+}
+
+func (i *Ignorer) FilterErrors(chartPath string, errs []error) []error {
+	out := make([]error, 0, len(errs))
+	for _, err := range errs {
+		if !i.ShouldKeepError(chartPath, err) {
+			continue
+		}
+
+		out = append(out, err)
+	}
+	return out
+}
+
+func (i *Ignorer) FilterMessages(chartPath string, messages []support.Message) []support.Message {
+	out := make([]support.Message, 0, len(messages))
+	for _, msg := range messages {
+		if !i.ShouldKeepMessage(chartPath, msg) {
+			continue
+		}
+		out = append(out, msg)
+	}
+	return out
+}
+
+func (i *Ignorer) ShouldKeepError(chartPath string, err error) bool {
+	return true
+}
+
+func (i *Ignorer) ShouldKeepMessage(chartPath string, msg support.Message) bool {
+	return true
+}

--- a/pkg/lint/support/message.go
+++ b/pkg/lint/support/message.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package support
 
-import "fmt"
+import (
+	"fmt"
+	"log/slog"
+)
 
 // Severity indicates the severity of a Message.
 const (
@@ -51,6 +54,14 @@ type Message struct {
 
 func (m Message) Error() string {
 	return fmt.Sprintf("[%s] %s: %s", sev[m.Severity], m.Path, m.Err.Error())
+}
+
+func (m Message) LogAttrs() slog.Attr {
+	return slog.Group("Message",
+		slog.Int("Severity", m.Severity),
+		slog.String("Path", m.Path),
+		slog.String("Err", m.Err.Error()),
+	)
 }
 
 // NewMessage creates a new Message struct


### PR DESCRIPTION
## How to capture all lints for a chart as YAML

```console
❯ go run ./cmd/helm lint ../gitlab/chart/ --with-subcharts --quiet | grep "^{" | yq -p=json > captures.yaml
```

See a full example output here: https://gist.github.com/dpritchett/884f9ac45a041434a349f9fcd1da1399

```console
❯ head captures.yaml
```

```yaml 
time: "2024-08-09T14:03:38.33318-05:00"
level: INFO
msg: action/lint/Run captured a message
chartIndex: 0
path: ../gitlab/chart/charts/certmanager-issuer
Message:
  Severity: 3
  Path: templates/
  Err: 'template: certmanager-issuer/templates/rbac-config.yaml:1:67: executing "certmanager-issuer/templates/rbac-config.yaml" at <.Values.global.ingress>: nil pointer evaluating interface {}.ingress'
---
```